### PR TITLE
#pulsar - Added support for Pulsar 1.5

### DIFF
--- a/.build/Localizable.strings
+++ b/.build/Localizable.strings
@@ -1,24 +1,21 @@
 
 
-/* Welcome Screen */
+/* Welcome Page */
 
-/* Use this everywhere user creates a new account */
-"signIn" = "Please Sign In";
+/* Use that as the boldest message */
+"welcomePage.header" = "Hell yeah!";
 
-/*  */
-"signOut" = "Sign Out from the application";
-
-/*  */
-"forgotPassword" = "Did you forget your password?";
+/* Slightly smaller message */
+"welcomePage.subheader" = "Hell naw!";
 
 
-/* Sign Up */
+/* Sign Up Page */
 
-/*  */
-"signUp" = "Sign up to the application";
+/* No Description */
+"signUpPage.signUp" = "Sign Up";
 
-/*  */
-"createUser" = "Create New User";
+/* No Description */
+"signUpPage.forgotPassword" = "Forgot password? Click Here";
 
-
-/* Text */
+/* No Description */
+"signUpPage.signIn" = "Sign In";

--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
     "organization": "Supernova",
     "homepage": "https://supernova.io",
     "source_dir": "src",
-    "version": "1.0.1",
+    "version": "1.1",
     "config": {
         "sources": "sources.json",
         "output": "output.json",

--- a/src/base-localizations.pr
+++ b/src/base-localizations.pr
@@ -5,11 +5,11 @@ Localization strings are grouped by the groups defined inside design system.
 Use javascript configuration in helpers.js to change how the resulting file looks like
 
 *}
-{[ let localizationGroups = @ds.tokenGroupsOfType("Text") /]}
+{[ let localizationGroups = ds.tokenGroupsOfType("Text") /]}
 {[ for group in localizationGroups ]}
 {* Exclude groups if they are empty *}
-{[ if @compare.greaterThan(group.tokenIds.count(), 0) ]}
-{[ let tokens = @ds.tokensByGroupId(group.id) /]}
+{[ if (group.tokenIds.count() > 0) ]}
+{[ let tokens = ds.tokensByGroupId(group.id) /]}
 
 {* Include group path name *}
 /* {{ group.path.append(group.name).join(" / ") }} */
@@ -17,10 +17,10 @@ Use javascript configuration in helpers.js to change how the resulting file look
 
 {* Include localization comments, if needed *}
 {[ if behavior.includeDescriptions ]}
-/* {{ @boolean.ternaryValue(@compare.greaterThan(text.description.count(), 0), text.description, "No description") }} */
+/* {{ (text.description && text.description.count() > 0) ? text.description : "No Description" }} */
 {[/]}
 {* Generate the localization key/value pair for each entry *}
-{[ let localizationKey = @js.localizationKey(text, group, behavior.includeGroupPrefixes) /]}
+{[ let localizationKey = localizationKey(text, group, behavior.includeGroupPrefixes) /]}
 "{{ localizationKey }}" = "{{ text.value.text }}";
 {[/]}
 {[/]}


### PR DESCRIPTION
This PR adds support for Pulsar 1.5

- All javascript calls now treated as top-level functions (no more `@js.` needed and will throw error if used) so all are reworked
- DS accessors are now proper methods on top-level `ds` object, so everything was reworked for this and autocomplete now properly works for those as well
- All ds methods are now actual methods, and can't have extra `.` inside it, so that was removed (for example, `@ds.fonts.isItalic` is now actually `ds.isFontItalic()`)
- Expressions have been simplified and syntax reworked to be aligned with new Pulsar, which follows JS syntax closely now
- Complex expressions inside flows must be surrounded with `()`, but expressions inside `{{ }}` don't need this, so reworked as well
- Added shorthands and object support, so you can use `{}` and `[]` to create empty objects and arrays, and all methods used previously to init etc. were removed
- `self` is `this` to align with javascript, and `self` is no longer available as global property

- Version of exporter bumped to next minor


Note for reviewer:
This PR CAN'T be merged and exporter run before Pulsar is merged to your environments, please don't merge it yourself.